### PR TITLE
Added an "OpenBeta" mode for DCS.OB users, Program now restores modifier button devices, Fixed bug in logfile read.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,10 @@ are happy with these actions, then re-run with the -x options:
 ```
 python dcs_input_restore.py -x
 ```
+If you're using **DCS** ***OpenBeta*** run the program with the -ob option:
+
+```
+python dcs_input_restore.py -x -ob
+```
 
 **Reccomend you make a backup of your DCS input directory before running the above step.**

--- a/dcs_input_restore.py
+++ b/dcs_input_restore.py
@@ -138,7 +138,7 @@ def main(args):
     if args.dcs_dir is None:
         dcs_dir = find_dcs_dir(args.openbeta)
     if not os.path.exists(dcs_dir):
-        raise ValueError("DCS directory {} does not exist".format(dcs_dir))
+        raise ValueError("DCS directory {} does not exist. Are you using DCS OpenBeta? run again with the -ob flag".format(dcs_dir))
     if not os.path.exists(os.path.join(dcs_dir, 'Config')):
         raise ValueError("Directory {} does not seem to contain a DCS profile".format(dcs_dir))
 
@@ -170,7 +170,7 @@ Suggested use: First run DCS on your new install. This will generate a
 new dcs.log file that contains the new joystick device profile
 names. Then run once with no arguments, which will print out a list of
 files that will be renamed.  If you are happy with these actions, then
-re-run with the -x options. If you use DCS open beta run with the -ob option"""
+re-run with the -x options. If you use DCS OpenBeta run with the -ob option"""
 
     parser = argparse.ArgumentParser(description=desc)
     parser.add_argument('--dcs_dir',

--- a/dcs_input_restore.py
+++ b/dcs_input_restore.py
@@ -5,8 +5,13 @@ import os
 import argparse
 from glob import glob
 
-def find_dcs_dir():
-    DCS_SAVEDGAMES_DIRNAME = 'DCS'
+
+def find_dcs_dir(openbeta):
+    if openbeta:
+        DCS_SAVEDGAMES_DIRNAME = 'DCS.openbeta'
+    else:
+        DCS_SAVEDGAMES_DIRNAME = 'DCS'
+
     userprofile = os.environ['USERPROFILE']
     dcs_dir = os.path.join(userprofile,
                            'Saved Games',
@@ -14,30 +19,38 @@ def find_dcs_dir():
 
     return dcs_dir
 
+
 def find_dcs_log(dcs_dir):
     return os.path.join(dcs_dir, 'Logs', 'dcs.log')
+
 
 def get_all_device_dirs(dcs_dir):
     all_inputs = glob(dcs_dir + '/config/input/*/joystick')
     return all_inputs
 
+
 def parse_dcs_log(dcs_dir):
     dev_names = []
     with open(find_dcs_log(dcs_dir), 'r') as f:
         dev_lines = []
-        INPUT_LOG_STR = 'INPUT: Joystick created['
+        INPUT_LOG_STR = 'INPUT (Main): created ['
+
         for line in f:
             if INPUT_LOG_STR in line:
-                _, l = line.split(INPUT_LOG_STR)
-                l, _ = l.split(']')
-                dev_names.append(l)
+                l = line[line.find("]") + 1:]
+                l = l[l.find("[") + 1: l.find("]")]
+                if len(l) > 3:
+                    dev_names.append(l)
+
     return set(dev_names)
+
 
 def split_device_filename(filename):
     l = filename.split('{')
     guid = ''.join(l[1:]).split('}')[0]
     device_name = l[0]
     return device_name, guid
+
 
 def find_dev_profiles_in(dirpath):
     def make_record(filepath):
@@ -48,10 +61,11 @@ def find_dev_profiles_in(dirpath):
             r.device_name, r.guid = split_device_filename(filename)
             r.time = os.path.getmtime(filepath)
             return r
-    
+
     filenames = glob(dirpath + '/*')
     return [make_record(filepath) for filepath in filenames
             if make_record(filepath) is not None]
+
 
 def find_unique_devices(records):
     devices = defaultdict(list)
@@ -93,17 +107,17 @@ def update_profiles_in(dirpath, new_devs, execute=False, quiet=False):
 
 def main(args):
     if args.dcs_dir is None:
-        dcs_dir = find_dcs_dir()
+        dcs_dir = find_dcs_dir(args.openbeta)
     if not os.path.exists(dcs_dir):
         raise ValueError("DCS directory {} does not exist".format(dcs_dir))
     if not os.path.exists(os.path.join(dcs_dir, 'Config')):
         raise ValueError("Directory {} does not seem to contain a DCS profile".format(dcs_dir))
-    
+
     new_devs = parse_dcs_log(dcs_dir)
-    print("*"*80)
+    print("*" * 80)
     print("Found the following new devices:")
     print("\n".join(new_devs))
-    print("*"*80)
+    print("*" * 80)
     print("\n\n")
     all_profile_dirs = get_all_device_dirs(dcs_dir)
     for dirname in all_profile_dirs:
@@ -111,7 +125,8 @@ def main(args):
                            new_devs,
                            execute=args.execute,
                            quiet=args.quiet)
-        
+
+
 if __name__ == '__main__':
     desc = """Convert DCS joystick profiles from a previous install.
 
@@ -122,20 +137,26 @@ Suggested use: First run DCS on your new install. This will generate a
 new dcs.log file that contains the new joystick device profile
 names. Then run once with no arguments, which will print out a list of
 files that will be renamed.  If you are happy with these actions, then
-re-run with the -x options.  """
+re-run with the -x options. If you use DCS open beta run with the -ob option"""
+
     parser = argparse.ArgumentParser(description=desc)
     parser.add_argument('--dcs_dir',
                         help='Provide path to DCS profiles directory to override default \"${USERPROFILE}/Saved Games/DCS\"')
-    
+
+    parser.add_argument('-ob',
+                        '--openbeta',
+                        help='Execute program in open beta mode (for DCS.openbeta)',
+                        action='store_true')
+
     parser.add_argument('-x',
                         '--execute',
                         help='Execute rename. Otherwise will only do a dry-run',
                         action='store_true')
-    
+
     parser.add_argument('--quiet',
                         help='Suppress output of files that are renamed',
                         action='store_true')
-    
+
     args = parser.parse_args()
-    
+
     main(args)

--- a/dcs_input_restore.py
+++ b/dcs_input_restore.py
@@ -39,6 +39,7 @@ def parse_dcs_log(dcs_dir):
             if INPUT_LOG_STR in line:
                 l = line[line.find("]") + 1:]
                 l = l[l.find("[") + 1: l.find("]")]
+                # Avoid appending empty strings to list. All devices should be longer than 3 chars as they include UID
                 if len(l) > 3:
                     dev_names.append(l)
 

--- a/dcs_input_restore.py
+++ b/dcs_input_restore.py
@@ -74,6 +74,7 @@ def find_unique_devices(records):
     for record in records:
         if record not in devices[record.device_name]:
             devices[record.device_name].append(record)
+            devices[" "+record.device_name].append(record) #account for potential leading white space in device name (this gets erased by windows in copies so we still want to match on it)
 
     def get_timestamp(rec):
         return rec.time


### PR DESCRIPTION
Program can now be used in "OpenBeta" mode with -ob flag. 
Program will now also edit modifiers.lua files in module config root folder.

Changed how the program reads Log files (format seems to have changed since this was last updated). 
Program now reads for any inputs instead of just "Joystick". 
Program also uses string slicing instead of splitting to prevent too many arguments being returned.

Tested and working with Windows11 & DCS OpenBeta 2.9.1